### PR TITLE
feat: Add 2FA compatibility and add needed rights on account

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -40,10 +40,7 @@
     },
     "accounts": {
       "description": "Required to get the account's data",
-      "type": "io.cozy.accounts",
-      "verbs": [
-        "GET"
-      ]
+      "type": "io.cozy.accounts"
     }
   },
   "developer": {


### PR DESCRIPTION
Voila la PR qui ajoute le 2FA au connecteur digiposte.
Testée sur la prod, tout marche bien, il suffira de tester une fois la future béta.

Je lève une nouvelle erreur car aucune ne convenait vraiment.
USER_ACTION_NEEDED.TWOFA_FAILED

@doubleface tu es ok, ou tu préfères qu'on garde USER_ACTION_NEEDED.TWOFA_EXPIRED ?

Merci