### PR TITLE
feat: Add 2FA avoidance, fix some case detection, refactor 2FA part

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -92,7 +92,8 @@
     "METADATA_DEDUP",
     "CAPTCHA_RESOLUTION",
     "CARBON_COPY",
-    "DOC_QUALIFICATION_V2"
+    "DOC_QUALIFICATION_V2",
+    "SENTRY_V2"
   ],
   "manifest_version": "2"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 process.env.SENTRY_DSN =
   process.env.SENTRY_DSN ||
-  'https://f6f64db44c394bb3856d0198732634bf@sentry.cozycloud.cc/95'
+  'https://1e88c603fffe475ba9593efe0595f0ad@errors.cozycloud.cc/61'
 
 const {
   BaseKonnector,


### PR DESCRIPTION
This PR do multiple corrective actions around the login.

Things done to be noted :
- Home page is now with a /home, login detection fixed
- We now avoid the webpage proposing to add 2FA and to add phone number (2 distincts pages, yes!)
- We now can take 2FA step, 2FA adding invitation or Phone adding invitation in random order, it's working. (automation in the while(...))
- Detection of fake login_failed when captcha seems to failed, I throw VENDOR_DOWN.CAPTCHA_FAILED

Some optimisations too:
- Reducing large regexp to be more tolerant
- Refactoring some code to reduce duplication
- Non necessary headers removed



To add some crazyness, please note the ' and " usage on the website script.
Always ```page_name: "blablablaMYSTEPbla" ``` but when they want you to add 2FA, no, something happen and they use ```page_name: 'connexion_add_2FA'```     
:)