### PR TITLE
[SCR-683] feat: Change category in the manifest

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -9,7 +9,7 @@
   "editor": "Cozy",
   "vendor_link": "https://secure.digiposte.fr/identification-plus",
   "categories": [
-    "online_services"
+    "clouds"
   ],
   "screenshots": [],
   "fields": {


### PR DESCRIPTION
Replace category in manifest for the konnector to display in "clouds and vaults" category in the store